### PR TITLE
Added metadata arg to make_declarative_base

### DIFF
--- a/flask_alchy.py
+++ b/flask_alchy.py
@@ -16,7 +16,8 @@ class Alchy(SQLAlchemy, ManagerMixin):
                  app=None,
                  use_native_unicode=True,
                  session_options=None,
-                 Model=None):
+                 Model=None,
+                 metadata=None):
         if session_options is None:
             session_options = {}
 
@@ -25,13 +26,13 @@ class Alchy(SQLAlchemy, ManagerMixin):
         self.Model = Model
 
         super(Alchy, self).__init__(
-            app, use_native_unicode, session_options)
+            app, use_native_unicode, session_options, metadata=metadata)
 
         self.Query = session_options['query_cls']
 
-    def make_declarative_base(self):
+    def make_declarative_base(self, metadata=None):
         """Override parent function with alchy's"""
-        return make_declarative_base(self.session, Model=self.Model)
+        return make_declarative_base(self.session, Model=self.Model, metadata=metadata)
 
     def __getattr__(self, attr):
         """Delegate all other attributes to self.session"""

--- a/flask_alchy.py
+++ b/flask_alchy.py
@@ -16,7 +16,8 @@ class Alchy(SQLAlchemy, ManagerMixin):
                  app=None,
                  use_native_unicode=True,
                  session_options=None,
-                 Model=None):
+                 Model=None,
+                 metadata=None):
         if session_options is None:
             session_options = {}
 
@@ -25,13 +26,14 @@ class Alchy(SQLAlchemy, ManagerMixin):
         self.Model = Model
 
         super(Alchy, self).__init__(
-            app, use_native_unicode, session_options)
+            app, use_native_unicode, session_options, metadata=metadata)
 
         self.Query = session_options['query_cls']
 
-    def make_declarative_base(self):
+    def make_declarative_base(self, metadata=None):
         """Override parent function with alchy's"""
-        return make_declarative_base(self.session, Model=self.Model)
+        return make_declarative_base(self.session, Model=self.Model,
+                                     metadata=metadata)
 
     def __getattr__(self, attr):
         """Delegate all other attributes to self.session"""


### PR DESCRIPTION
This is to fix a compatibility issue with the latest released version of Flask-SqlAlchemy.

The method `SQLAlchemy.make_declarative_base` has changed signature: now it takes 1 argument which is an instance of the metaclass. This method is called in the `__init__` method of the SQLAlchemy object:

``` python
class SQLAlchemy(object):
        def __init__(self, app=None, use_native_unicode=True, session_options=None, metadata=None):
                [...]
                self.Model = self.make_declarative_base(metadata)
                [...]
```

The `Alchy` class inherits from this one: in order to make it work we have to change its own implementation of  `make_declarative_base` accordingly.

This PR is intended to be committed together with [Alchy PR #29](https://github.com/dgilland/alchy/pull/29) 
